### PR TITLE
Inference naming fix

### DIFF
--- a/kafkatime/src/main/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchema.scala
+++ b/kafkatime/src/main/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchema.scala
@@ -39,17 +39,13 @@ object JsonToAvroSchema {
 
         val nodeName = validName(name)
 
-        val arrayElemSchema = inferSchema(it.next(),
-                                          SchemaBuilder.builder(),
-                                          nodeName,
-                                          namespace)
+        val arrayElemSchema =
+          inferSchema(it.next(), SchemaBuilder.builder(), nodeName, namespace)
 
         it.forEachRemaining(
           x =>
-            if (!arrayElemSchema.equals(inferSchema(x,
-                                                    SchemaBuilder.builder(),
-                                                    nodeName,
-                                                    namespace)))
+            if (!arrayElemSchema.equals(
+                  inferSchema(x, SchemaBuilder.builder(), nodeName, namespace)))
               throw new IllegalArgumentException(
                 "Array contains elements of different types."))
 
@@ -64,7 +60,10 @@ object JsonToAvroSchema {
           newSchema
             .name(fieldName)
             .`type`(
-              inferSchema(x.getValue, SchemaBuilder.builder(), fieldName, namespace + '.' + nodeName))
+              inferSchema(x.getValue,
+                          SchemaBuilder.builder(),
+                          fieldName,
+                          namespace + '.' + nodeName))
             .noDefault()
         })
         newSchema.endRecord()
@@ -121,9 +120,8 @@ object JsonToAvroSchema {
     */
   private def validName(name: String): String = {
     val tempName = name.replaceAll("\\W", "_")
-    if (!name.isBlank && (tempName
-          .charAt(0)
-          .isLetter || tempName.charAt(0) == '_'))
+    if (!name.isBlank &&
+        (tempName.charAt(0).isLetter || tempName.charAt(0) == '_'))
       return tempName
     '_' + tempName
   }

--- a/kafkatime/src/main/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchema.scala
+++ b/kafkatime/src/main/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchema.scala
@@ -50,7 +50,7 @@ object JsonToAvroSchema {
 
         schema.array().items(arrayElemSchema)
 
-      case JsonNodeType.OBJECT =>
+      case JsonNodeType.OBJECT | JsonNodeType.POJO =>
         val newSchema = schema.record(validName(name)).fields()
         node.fields.forEachRemaining(x => {
           val name = validName(x.getKey)
@@ -69,8 +69,7 @@ object JsonToAvroSchema {
       case JsonNodeType.NUMBER =>
         if (node.isIntegralNumber) schema.longType() else schema.doubleType()
 
-      case x =>
-        throw new IllegalArgumentException("Unrecognized data type: " + x)
+      case JsonNodeType.NULL | JsonNodeType.MISSING => schema.nullType()
     }
 
   /**

--- a/kafkatime/src/main/scala/org/codefeedr/kafkatime/transforms/Register.scala
+++ b/kafkatime/src/main/scala/org/codefeedr/kafkatime/transforms/Register.scala
@@ -115,7 +115,7 @@ trait Register {
     */
   def extractTopics(query: String,
                     supportedPlugins: List[String]): List[String] = {
-    supportedPlugins.intersect(query.split("\\s+|,|;|\\(|\\)"))
+    supportedPlugins.intersect(query.split("\\s+|,|;|\\(|\\)|`"))
   }
 
   /**

--- a/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
+++ b/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
@@ -6,14 +6,17 @@ import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2}
 
 class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
 
+  val topicName = "myTopic"
+
   val testData: TableFor2[String, String] =
     Table(
       ("AvroSchema", "JsonSample"),
       (
-        """
+        s"""
           |{
           |    "type":"record",
-          |    "name":"myTopic",
+          |    "name":"$topicName",
+          |    "namespace":"infer",
           |    "fields":[
           |        {
           |            "name":"title",
@@ -44,10 +47,11 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |""".stripMargin
       ),
       (
-        """
+        s"""
           |{
           |    "type":"record",
-          |    "name":"myTopic",
+          |    "name":"$topicName",
+          |    "namespace":"infer",
           |    "fields":[
           |        {
           |            "name":"colors",
@@ -55,7 +59,8 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |                "type":"array",
           |                "items":{
           |                "type":"record",
-          |                "name":"colors_type_type",
+          |                "name":"colors",
+          |                "namespace":"infer.$topicName",
           |                "fields":[
           |                    {
           |                        "name":"color",
@@ -104,10 +109,11 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |""".stripMargin
       ),
       (
-        """
+        s"""
           |{
           |    "type":"record",
-          |    "name":"myTopic",
+          |    "name":"$topicName",
+          |    "namespace":"infer",
           |    "fields":[
           |        {
           |            "name":"id",
@@ -148,10 +154,11 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |""".stripMargin
       ),
       (
-        """
+        s"""
           |{
           |    "type":"record",
-          |    "name":"myTopic",
+          |    "name":"$topicName",
+          |    "namespace":"infer",
           |    "fields":[
           |        {
           |            "name":"id",
@@ -167,10 +174,11 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |""".stripMargin
       ),
       (
-        """
+        s"""
           |{
           |    "type":"record",
-          |    "name":"myTopic",
+          |    "name":"$topicName",
+          |    "namespace":"infer",
           |    "fields":[
           |        {
           |            "name":"field_field_",
@@ -207,7 +215,6 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
     */
   forAll(testData) { (avroSchema: String, jsonSample: String) =>
     assertResult(new Schema.Parser().parse(avroSchema)) {
-      val topicName = "myTopic"
       JsonToAvroSchema.inferSchema(jsonSample, topicName)
     }
   }
@@ -237,7 +244,6 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
     */
   forAll(exceptionalTestData) {jsonSample: String =>
     assertThrows[IllegalArgumentException] {
-      val topicName = "myTopic"
       JsonToAvroSchema.inferSchema(jsonSample, topicName)
     }
   }

--- a/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
+++ b/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
@@ -39,10 +39,10 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |""".stripMargin,
         """
           |{
-          |    "title":"noted-notes 0.1.4",
-          |    "link":"Noted is a cli note taking and todo app.",
-          |    "description":"https://pypi.org/project/noted-notes/0.1.4/",
-          |    "pubDate":"2020-06-14T19:42:46.000Z"
+          |    "title":"test-title",
+          |    "link":"https://example.com/",
+          |    "description":"test description",
+          |    "pubDate":"2020-06-14T19:42:10.000Z"
           |}
           |""".stripMargin
       ),

--- a/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
+++ b/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
@@ -64,6 +64,10 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |                    {
           |                        "name":"value",
           |                        "type":"string"
+          |                    },
+          |                    {
+          |                        "name":"other",
+          |                        "type":"null"
           |                    }
           |                ]
           |                }
@@ -77,19 +81,23 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
           |    "colors":[
           |        {
           |            "color":"red",
-          |            "value":"#f00"
+          |            "value":"#f00",
+          |            "other":null
           |        },
           |        {
           |            "color":"magenta",
-          |            "value":"#f0f"
+          |            "value":"#f0f",
+          |            "other":null
           |        },
           |        {
           |            "color":"red",
-          |            "value":"#f00"
+          |            "value":"#f00",
+          |            "other":null
           |        },
           |        {
           |            "color":"magenta",
-          |            "value":"#f0f"
+          |            "value":"#f0f",
+          |            "other":null
           |        }
           |    ]
           |}
@@ -221,8 +229,6 @@ class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
         |
         |    ]
         |}
-        |""".stripMargin,
-      """
         |""".stripMargin
     )
 

--- a/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
+++ b/kafkatime/src/test/scala/org/codefeedr/kafkatime/transforms/JsonToAvroSchemaTest.scala
@@ -1,153 +1,238 @@
 package org.codefeedr.kafkatime.transforms
 
+import org.apache.avro.Schema
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor2}
-
-import scala.tools.nsc.doc.base.comment.Table
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2}
 
 class JsonToAvroSchemaTest extends AnyFunSuite with TableDrivenPropertyChecks {
 
-
   val testData: TableFor2[String, String] =
-    Table(("AvroSchema", "JsonSample"),
+    Table(
+      ("AvroSchema", "JsonSample"),
       (
-        """{
-  "type" : "record",
-  "name" : "myTopic",
-  "fields" : [ {
-    "name" : "title",
-    "type" : "string"
-  }, {
-    "name" : "link",
-    "type" : "string"
-  }, {
-    "name" : "description",
-    "type" : "string"
-  }, {
-    "name" : "pubDate",
-    "type" : "string"
-  } ]
-}""",
         """
-{
-    "title":"noted-notes 0.1.4",
-    "link":"Noted is a cli note taking and todo app similar to google keep or any other note taking service. It is a fork of my previous project keep-cli. Notes appear as cards. You can make lists and write random ideas.",
-    "description":"https://pypi.org/project/noted-notes/0.1.4/",
-    "pubDate":"2020-06-14T19:42:46.000Z"
- }
-                       """), (
-        """{
-  "type" : "record",
-  "name" : "myTopic",
-  "fields" : [ {
-    "name" : "colors",
-    "type" : {
-      "type" : "array",
-      "items" : {
-        "type" : "record",
-        "name" : "colors_type_type",
-        "fields" : [ {
-          "name" : "color",
-          "type" : "string"
-        }, {
-          "name" : "value",
-          "type" : "string"
-        } ]
-      }
-    }
-  } ]
-}""",
+          |{
+          |    "type":"record",
+          |    "name":"myTopic",
+          |    "fields":[
+          |        {
+          |            "name":"title",
+          |            "type":"string"
+          |        },
+          |        {
+          |            "name":"link",
+          |            "type":"string"
+          |        },
+          |        {
+          |            "name":"description",
+          |            "type":"string"
+          |        },
+          |        {
+          |            "name":"pubDate",
+          |            "type":"string"
+          |        }
+          |    ]
+          |}
+          |""".stripMargin,
         """
-{
-"colors" : [
-	{
-		"color": "red",
-		"value": "#f00"
-	},
-	{
-		"color": "magenta",
-		"value": "#f0f"
-	},
-	{
-		"color": "red",
-		"value": "#f00"
-	},
-	{
-		"color": "magenta",
-		"value": "#f0f"
-	}
-]
-}"""), (
-        """{
-          |  "type" : "record",
-          |  "name" : "myTopic",
-          |  "fields" : [ {
-          |    "name" : "id",
-          |    "type" : "long"
-          |  }, {
-          |    "name" : "age",
-          |    "type" : "long"
-          |  }, {
-          |    "name" : "bornyear",
-          |    "type" : "long"
-          |  }, {
-          |    "name" : "date",
-          |    "type" : "long"
-          |  }, {
-          |    "name" : "month",
-          |    "type" : "long"
-          |  }, {
-          |    "name" : "weight",
-          |    "type" : "double"
-          |  } ]
-          |}""".stripMargin,
-        """{
-      "id": 1,
-      "age": 56,
-      "bornyear": 1963,
-      "date": 3,
-      "month": 7,
-      "weight" : 67.5
-    }"""), (
-        """{
-          |  "type" : "record",
-          |  "name" : "myTopic",
-          |  "fields" : [ {
-          |    "name" : "id",
-          |    "type" : "boolean"
-          |  } ]
-          |}""".stripMargin,
-        """{
-      "id": true
-    }"""))
-
+          |{
+          |    "title":"noted-notes 0.1.4",
+          |    "link":"Noted is a cli note taking and todo app.",
+          |    "description":"https://pypi.org/project/noted-notes/0.1.4/",
+          |    "pubDate":"2020-06-14T19:42:46.000Z"
+          |}
+          |""".stripMargin
+      ),
+      (
+        """
+          |{
+          |    "type":"record",
+          |    "name":"myTopic",
+          |    "fields":[
+          |        {
+          |            "name":"colors",
+          |            "type":{
+          |                "type":"array",
+          |                "items":{
+          |                "type":"record",
+          |                "name":"colors_type_type",
+          |                "fields":[
+          |                    {
+          |                        "name":"color",
+          |                        "type":"string"
+          |                    },
+          |                    {
+          |                        "name":"value",
+          |                        "type":"string"
+          |                    }
+          |                ]
+          |                }
+          |            }
+          |        }
+          |    ]
+          |}
+          |""".stripMargin,
+        """
+          |{
+          |    "colors":[
+          |        {
+          |            "color":"red",
+          |            "value":"#f00"
+          |        },
+          |        {
+          |            "color":"magenta",
+          |            "value":"#f0f"
+          |        },
+          |        {
+          |            "color":"red",
+          |            "value":"#f00"
+          |        },
+          |        {
+          |            "color":"magenta",
+          |            "value":"#f0f"
+          |        }
+          |    ]
+          |}
+          |""".stripMargin
+      ),
+      (
+        """
+          |{
+          |    "type":"record",
+          |    "name":"myTopic",
+          |    "fields":[
+          |        {
+          |            "name":"id",
+          |            "type":"long"
+          |        },
+          |        {
+          |            "name":"age",
+          |            "type":"long"
+          |        },
+          |        {
+          |            "name":"year",
+          |            "type":"long"
+          |        },
+          |        {
+          |            "name":"day",
+          |            "type":"long"
+          |        },
+          |        {
+          |            "name":"month",
+          |            "type":"long"
+          |        },
+          |        {
+          |            "name":"weight",
+          |            "type":"double"
+          |        }
+          |    ]
+          |}
+          |""".stripMargin,
+        """
+          |{
+          |    "id":1,
+          |    "age":56,
+          |    "year":1963,
+          |    "day":3,
+          |    "month":7,
+          |    "weight":67.5
+          |}
+          |""".stripMargin
+      ),
+      (
+        """
+          |{
+          |    "type":"record",
+          |    "name":"myTopic",
+          |    "fields":[
+          |        {
+          |            "name":"id",
+          |            "type":"boolean"
+          |        }
+          |    ]
+          |}
+          |""".stripMargin,
+        """
+          |{
+          |    "id":true
+          |}
+          |""".stripMargin
+      ),
+      (
+        """
+          |{
+          |    "type":"record",
+          |    "name":"myTopic",
+          |    "fields":[
+          |        {
+          |            "name":"field_field_",
+          |            "type":"string"
+          |        },
+          |        {
+          |            "name":"_",
+          |            "type":"string"
+          |        },
+          |        {
+          |            "name":"_field",
+          |            "type":"string"
+          |        },
+          |        {
+          |            "name":"_0field",
+          |            "type":"string"
+          |        }
+          |    ]
+          |}
+          |""".stripMargin,
+        """
+          |{
+          |    "field.field/":"test1",
+          |    "":"test2",
+          |    "/field":"test3",
+          |    "0field":"test4"
+          |}
+          |""".stripMargin
+      )
+    )
 
   /**
     * Parameterized good weather tests for all supported types.
     */
   forAll(testData) { (avroSchema: String, jsonSample: String) =>
-    assertResult(avroSchema) {
+    assertResult(new Schema.Parser().parse(avroSchema)) {
       val topicName = "myTopic"
-      JsonToAvroSchema.inferSchema(jsonSample, topicName).toString(true)
+      JsonToAvroSchema.inferSchema(jsonSample, topicName)
     }
   }
 
-  assertThrows[IllegalArgumentException] {
-    val jsonSample =
+  val exceptionalTestData: TableFor1[String] =
+    Table(
+      "JsonSample",
       """
-         {
-         "badWeather" : [
-         1, "hello"
-         ]
-         }
-        """.stripMargin
-    val topicName = "myTopic"
-    JsonToAvroSchema.inferSchema(jsonSample, topicName).toString(true)
-  }
+        |{
+        |    "badWeather":[
+        |        1,
+        |        "hello"
+        |    ]
+        |}
+        |""".stripMargin,
+      """
+        |{
+        |    "badWeather":[
+        |
+        |    ]
+        |}
+        |""".stripMargin,
+      """
+        |""".stripMargin
+    )
 
-  assertThrows[IllegalArgumentException] {
-    val jsonSample = ""
-    val topicName = "myTopic"
-    JsonToAvroSchema.inferSchema(jsonSample, topicName).toString(true)
+  /**
+    * Parameterized bad weather tests.
+    */
+  forAll(exceptionalTestData) {jsonSample: String =>
+    assertThrows[IllegalArgumentException] {
+      val topicName = "myTopic"
+      JsonToAvroSchema.inferSchema(jsonSample, topicName)
+    }
   }
 }


### PR DESCRIPTION
Schema inference now replaces characters which are not allowed within Avro field names with underscores ('_').

Also refactored schema inference tests.

Proper use of namespaces for (sub-)schemas is made.